### PR TITLE
✨feat(posts): add endpoint to retrieve all posts with user details

### DIFF
--- a/src/controllers/post.controller.ts
+++ b/src/controllers/post.controller.ts
@@ -1,6 +1,6 @@
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { AuthRequest } from '../types/jwt.js';
-import { createPost } from '../services/post.service.js';
+import { createPost, getAllPosts } from '../services/post.service.js';
 import { handleControllerError } from '../utils/errorResponse.js';
 
 export const createPostController = async (req: AuthRequest, res: Response) => {
@@ -22,5 +22,14 @@ export const createPostController = async (req: AuthRequest, res: Response) => {
     res.status(201).json(post);
   } catch (error) {
     handleControllerError(res, error, 'Error when creating the publication.');
+  }
+};
+
+export const getPostsController = async (_req: Request, res: Response) => {
+  try {
+    const posts = await getAllPosts();
+    res.json(posts);
+  } catch (error) {
+    handleControllerError(res, error, 'Error obtaining publications.');
   }
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,7 +7,7 @@ const router = Router();
 
 router.use('/auth', authRouter);
 router.use('/user', userRouter);
-router.use('/post', postRouter);
+router.use('/posts', postRouter);
 
 router.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });

--- a/src/routes/post.router.ts
+++ b/src/routes/post.router.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { authenticateJWT } from '../middlewares/authenticateJWT.middleware.js';
-import { createPostController } from '../controllers/post.controller.js';
+import { createPostController, getPostsController } from '../controllers/post.controller.js';
 
 const router = Router();
 
-router.post('/profile', authenticateJWT, createPostController);
+router.post('/', authenticateJWT, createPostController);
+router.get('/', authenticateJWT, getPostsController);
 
 export default router;

--- a/src/services/post.service.ts
+++ b/src/services/post.service.ts
@@ -17,3 +17,28 @@ export const createPost = async (userId: string, message: string) => {
     },
   });
 };
+
+export const getAllPosts = async () => {
+  return prisma.post.findMany({
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      message: true,
+      createdAt: true,
+      user: {
+        select: {
+          id: true,
+          alias: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+      likes: {
+        select: {
+          id: true,
+          userId: true,
+        },
+      },
+    },
+  });
+};


### PR DESCRIPTION
### ✨ Context

All posts can now be retrieved through a dedicated endpoint that returns posts ordered by creation date, including user and like details. Route definitions were also updated for RESTful consistency and clarity.

### 🛠 Changes

- ✨[controllers]Add getPostsController for retrieving all posts
  - Implemented getPostsController to fetch all posts from the database.
  - Updated imports to include getAllPosts function from post.service.js.

- ✨[services]Add getAllPosts function for retrieving posts with user details
  - Implemented a new function to fetch all posts from the database.
  - Posts are ordered by creation date and include user information and likes.

- 🐛[routes]Fix post router endpoint and add getPosts functionality
  - Updated post router to use '/posts' instead of '/post' for consistency.
  - Added getPostsController to retrieve all posts.
  - Changed post creation endpoint to '/' for better RESTful practices.


### 📘 Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

### 🧪 Test

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

### 📸 Screenshots (optional)

n/a
