### PR TITLE
✨feat(posts): add like post functionality with endpoint and controller

### DIFF
--- a/src/controllers/like.controller.ts
+++ b/src/controllers/like.controller.ts
@@ -1,0 +1,27 @@
+import { Response } from 'express';
+import { AuthRequest } from '../types/jwt.js';
+import { likePost } from '../services/like.service.js';
+import { handleControllerError } from '../utils/errorResponse.js';
+
+export const likePostController = async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.userId;
+    const { id: postId } = req.params;
+
+    if (!userId) {
+      res.status(401).json({ error: 'User not authenticated.' });
+      return;
+    }
+
+    const result = await likePost(postId, userId);
+
+    if ('alreadyLiked' in result) {
+      res.status(200).json({ message: 'You already like this publication.' });
+      return;
+    }
+
+    res.status(201).json(result);
+  } catch (error) {
+    handleControllerError(res, error, 'Error when giving like.');
+  }
+};

--- a/src/routes/post.router.ts
+++ b/src/routes/post.router.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import { authenticateJWT } from '../middlewares/authenticateJWT.middleware.js';
 import { createPostController, getPostsController } from '../controllers/post.controller.js';
+import { likePostController } from '../controllers/like.controller.js';
 
 const router = Router();
 
 router.post('/', authenticateJWT, createPostController);
 router.get('/', authenticateJWT, getPostsController);
+router.post('/:id/like', authenticateJWT, likePostController);
 
 export default router;

--- a/src/services/like.service.ts
+++ b/src/services/like.service.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const likePost = async (postId: string, userId: string) => {
+  const exists = await prisma.like.findUnique({
+    where: { userId_postId: { userId, postId } },
+  });
+
+  if (exists) {
+    return { alreadyLiked: true };
+  }
+
+  const like = await prisma.like.create({
+    data: { userId, postId },
+  });
+
+  return like;
+};


### PR DESCRIPTION
### ✨ Context

A new like post feature was implemented, allowing authenticated users to like posts via a dedicated endpoint. The service ensures users cannot like the same post multiple times and appropriate responses are returned based on the like status.

### 🛠 Changes

- ✨[services]Add likePost function for liking posts
  - Implemented a new service function to allow users to like posts.
  - Checks if the user has already liked the post before creating a new like entry.

- ✨[routes]Add likePost endpoint for liking posts
  - Implemented a new POST route to allow users to like a post by its ID.
  - Integrated the likePostController to handle the like functionality.

- ✨[controllers]Add likePostController for liking posts
  - Implemented likePostController to handle post liking functionality.
  - Validates user authentication before allowing likes.
  - Returns appropriate responses based on like status.


### 📘 Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

### 🧪 Test

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

### 📸 Screenshots (optional)

n/a
