### PR TITLE
✨feat(posts): refactor like functionality to toggle likes and return counts

### DIFF
--- a/src/controllers/like.controller.ts
+++ b/src/controllers/like.controller.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { AuthRequest } from '../types/jwt.js';
-import { likePost } from '../services/like.service.js';
+import { toggleLikePost } from '../services/like.service.js';
 import { handleControllerError } from '../utils/errorResponse.js';
 
 export const likePostController = async (req: AuthRequest, res: Response) => {
@@ -13,15 +13,9 @@ export const likePostController = async (req: AuthRequest, res: Response) => {
       return;
     }
 
-    const result = await likePost(postId, userId);
-
-    if ('alreadyLiked' in result) {
-      res.status(200).json({ message: 'You already like this publication.' });
-      return;
-    }
-
-    res.status(201).json(result);
+    const result = await toggleLikePost(postId, userId);
+    res.status(200).json(result);
   } catch (error) {
-    handleControllerError(res, error, 'Error when giving like.');
+    handleControllerError(res, error, 'Error when toggling like.');
   }
 };

--- a/src/controllers/post.controller.ts
+++ b/src/controllers/post.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { AuthRequest } from '../types/jwt.js';
 import { createPost, getAllPosts } from '../services/post.service.js';
 import { handleControllerError } from '../utils/errorResponse.js';
@@ -25,9 +25,14 @@ export const createPostController = async (req: AuthRequest, res: Response) => {
   }
 };
 
-export const getPostsController = async (_req: Request, res: Response) => {
+export const getPostsController = async (req: AuthRequest, res: Response) => {
   try {
-    const posts = await getAllPosts();
+    const userId = req.user?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'User not authenticated.' });
+      return;
+    }
+    const posts = await getAllPosts(userId);
     res.json(posts);
   } catch (error) {
     handleControllerError(res, error, 'Error obtaining publications.');

--- a/src/services/like.service.ts
+++ b/src/services/like.service.ts
@@ -1,19 +1,26 @@
 import { PrismaClient } from '@prisma/client';
-
 const prisma = new PrismaClient();
 
-export const likePost = async (postId: string, userId: string) => {
+export const toggleLikePost = async (postId: string, userId: string) => {
   const exists = await prisma.like.findUnique({
     where: { userId_postId: { userId, postId } },
   });
 
+  let liked: boolean;
+
   if (exists) {
-    return { alreadyLiked: true };
+    await prisma.like.delete({
+      where: { userId_postId: { userId, postId } },
+    });
+    liked = false;
+  } else {
+    await prisma.like.create({
+      data: { userId, postId },
+    });
+    liked = true;
   }
 
-  const like = await prisma.like.create({
-    data: { userId, postId },
-  });
+  const likesCount = await prisma.like.count({ where: { postId } });
 
-  return like;
+  return { id: postId, liked, likesCount };
 };

--- a/src/services/post.service.ts
+++ b/src/services/post.service.ts
@@ -18,27 +18,28 @@ export const createPost = async (userId: string, message: string) => {
   });
 };
 
-export const getAllPosts = async () => {
-  return prisma.post.findMany({
-    orderBy: { createdAt: 'desc' },
-    select: {
-      id: true,
-      message: true,
-      createdAt: true,
+export const getAllPosts = async (currentUserId: string) => {
+  const posts = await prisma.post.findMany({
+    include: {
       user: {
         select: {
           id: true,
-          alias: true,
           firstName: true,
           lastName: true,
+          alias: true,
         },
       },
-      likes: {
-        select: {
-          id: true,
-          userId: true,
-        },
-      },
+      likes: { select: { userId: true } },
     },
+    orderBy: { createdAt: 'desc' },
   });
+
+  return posts.map((post) => ({
+    id: post.id,
+    message: post.message,
+    user: post.user,
+    likesCount: post.likes.length,
+    likedByCurrentUser: post.likes.some((like) => like.userId === currentUserId),
+    createdAt: post.createdAt,
+  }));
 };


### PR DESCRIPTION
### ✨ Context

The like functionality was refactored to toggle the like status for a post. The service and controller now return the post ID, whether the post is liked, and the updated likes count, improving clarity and frontend integration.


### 🛠 Changes

- ✨[services]Refactor likePost function to toggle likes and return counts 
  - Renamed `likePost` to `toggleLikePost` for clarity on functionality.
  - Updated logic to toggle likes: delete if exists, create if not.
  - Returns the post ID, like status, and total likes count.

- ♻️[controllers]Refactor likePostController to use toggleLikePost service 
  - Replaced likePost service with toggleLikePost for better functionality.
  - Updated response handling to reflect changes in the like toggling process.
  - Improved error handling message for clarity.


### 📘 Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

### 🧪 Test

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

### 📸 Screenshots (optional)

n/a